### PR TITLE
Added option to define step

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If You need to add special characters in the metric name such as `:` or a space,
 
 The default step is 60 seconds.
 If the series in Graphite have a different step, use `graphite_step` hint at map, node or link level.
-Use for example `SET graphite_step 500` if the time per point is 5 minutes.
+Use for example `SET graphite_step 300` if the time per point is 5 minutes.
 
 [perSecond]: https://graphite.readthedocs.io/en/latest/functions.html#graphite.render.functions.perSecond
 [seriesByTag]: https://graphite.readthedocs.io/en/latest/functions.html#graphite.render.functions.seriesByTag

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ This is mainly useful in combination with the aggregation feature, where you can
 The metric name can also include functions like [perSecond] or [seriesByTag].
 If You need to add special characters in the metric name such as `:` or a space, it is better to URL encode it.
 
+The default step is 60 seconds.
+If the series in Graphite have a different step, use `graphite_step` hint at map, node or link level.
+Use for example `SET graphite_step 500` if the time per point is 5 minutes.
+
 [perSecond]: https://graphite.readthedocs.io/en/latest/functions.html#graphite.render.functions.perSecond
 [seriesByTag]: https://graphite.readthedocs.io/en/latest/functions.html#graphite.render.functions.seriesByTag
 


### PR DESCRIPTION
To reduce the amount of metric points returned, I added a step value that defaults to 1 minute. The plugin now loads metrics from 2 times the step until now. So that will mostly be also 2 metrics and good enough if you want to do `perSecond` calculation on the series.